### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Access the floating view by sending the floatingHeaderView message to the UIScro
 ### Known Issues
 None yet.
 
-###Contributions
+### Contributions
 - Contributions and suggestions are welcome.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
